### PR TITLE
Fixed error in application.rb from when rack/cors was added.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,24 +1,23 @@
- require 'rack'
-require 'rack/cors'
+require_relative 'boot'
+
+require 'rails/all'
 
  module Agency
    class Application < Rails::Application
 
      # ...
-    
+
      # Rails 5
+   #
+   #  config.middleware.insert_before 0, Rack::Cors do
+   #     allow do
+   #       origins '*'
+   # resource '*', :headers => :any, :methods => [:get, :post, :delete, :put, :options]
+     #   end
+     # end
 
-    config.middleware.insert_before 0, Rack::Cors do
-       allow do
-         origins '*'
-   resource '*', :headers => :any, :methods => [:get, :post, :delete, :put, :options]
-       end
-     end
 
 
-require_relative 'boot'
-
-require 'rails/all'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
I was not able to run "rails db:migrate" because rails had not been required at the top of the file, at some point it had been moved down in the file.